### PR TITLE
Section Prior information completely rewritten

### DIFF
--- a/AYSS-2017/article/ayss2017-Zeleniy.tex
+++ b/AYSS-2017/article/ayss2017-Zeleniy.tex
@@ -78,54 +78,86 @@ Let us consider what a prior information can we use?
 
 \subsection{A prior information}\label{sec:theory:aprior}
 
-A general case of prior information is assumption about function smoothness. The applications of such prior information is done in three stages:
-\begin{enumerate}
-\item Minimize additional Shannon's information:
-	\begin{equation*}
-		I[P(\varphi)] = \int \ln{P(\varphi)} P(\varphi) d\varphi \to min
-	\end{equation*}
-\item Normalize probability density:
-	\begin{equation*}
-		\int P(\varphi) d\varphi = 1
-	\end{equation*}   
-\item Analyze information about smoothness of function $\varphi(x)$:
-	\begin{equation}
-		\label{eq-smoothness}
-		\int \langle \varphi,\hat{\Omega}\varphi \rangle P(\varphi) d\varphi = \omega,
-	\end{equation}
-where $\omega$ - required level of smoothness,   $\hat{\Omega}$ - operator of smoothness (for example, $\hat{\Omega}=|\frac{d^2}{dx^2}\left\rangle\right\langle\frac{d^2}{dx^2}|$).
-\end{enumerate}
+We expect that $\varphi$ is relatively smooth and doesn't contain wild
+oscillations which naive least squares usually produce. Common way of measuring
+function's smoothness is $\langle\varphi,\hat{\Omega}\varphi\rangle$, where
+$\hat{\Omega}=|\frac{d^2}{dx^2}\left\rangle\right\langle\frac{d^2}{dx^2}|$.
+At the same time we want to minimize information content of prior. 
+
+Reasonable choice is ensemble of functions with average smoothness $\omega$ which
+maximizes Shannon entropy. Which means we need to maximize:
+
+\begin{equation*}
+  H[P(\varphi)] = -\int \ln{P(\varphi)} P(\varphi) d\varphi
+\end{equation*}
+
+Subject to constraints:
+
+\begin{equation}
+  \int P(\varphi) d\varphi = 1
+  \qquad\mbox{and}\qquad
+  \int \langle \varphi,\hat{\Omega}\varphi \rangle P(\varphi) d\varphi = \omega,  
+  \label{eq-smoothness}
+\end{equation}
 
 The resulting prior probability density for the Gaussian random process:
 \begin{equation}
-	P_{\alpha}(\vec{\varphi})  = \frac{\alpha^{Rg(\Omega)/2}\det\Omega^{1/2}}{(2\pi)^{N/2}} 
-    \exp\left(-\frac{1}{2}(\vec{\varphi},\alpha\Omega\vec{\varphi})\right),
+  P(\vec{\varphi}|\alpha) = \frac{\det(\alpha\Omega)^{1/2}}{(2\pi)^{N/2}} 
+  \exp\left(-\frac{1}{2}\langle\vec{\varphi},\alpha\Omega\vec{\varphi}\rangle\right),
+  \label{eq-prior}
 \end{equation}
-where  $\alpha = \alpha(\omega)$ - parameter of smoothness.
-The prior information depends on $\alpha$-smoothness parameter. This parameter could be estimated in a few different ways: \\
-\indent a) select manually using known smoothness, but this is rare probability; \\
-\indent b) use most probable parameter: $\alpha^* = \max P(\alpha|f);$ \\
-\indent c) use a prior information about smoothness: 
+
+where $\alpha = \alpha(\omega)$~--- parameter of smoothness. Now we have problem
+of picking $\alpha$. Information about its value almost never available so we
+could consider it random variable as well. This yields us hierarchical Bayes
+model:
+
+\begin{equation}
+  P(f,\varphi,\alpha) = P(f|\varphi)P(\varphi,\alpha)P(\alpha)
+\end{equation}
+
+Since we don't have any information about $\alpha$ we chose hyperprior
+$P(\alpha)$ to be flat. Now we have several options to pursue:
+
+\begin{enumerate}
+\item Use fully Bayesian approach and marginalize $\alpha$:
   \begin{equation}\label{eq:varAposteriorAlpha}
-      P(\varphi)  = \int P_{\alpha}(\varphi) P(\alpha)~d\alpha ;
+      P(\varphi) = \int P(\varphi|\alpha) P(\alpha)~d\alpha
   \end{equation}
-\indent d) use a posterior information about smoothness: 
-  \begin{equation}\label{eq:solveAposteriorAlpha}
-      \hat{S}[f] = \int d\alpha \hat{S}_{\alpha}[f] P(\alpha|f).
-  \end{equation} 
-In fact, methods (c) and (d) are equivalent.
+  In general case MCMC could be used to sample $\varphi$ from full
+  posterior. And for Gaussian errors it could be reduced to numerical integral.
+  
+\item Use empirical Bayes: pick $\alpha$ corresponding to most probable
+  $P(\alpha|f)$
 
-\subsection{Additional prior information}
+  \begin{equation}
+    P(\alpha|f) = \int d\varphi~P(f|\varphi)P(\varphi|\alpha)P(\alpha)
+  \end{equation}
 
-In eq.~\ref{eq-smoothness} one can use not only smoothness operator, but also different or even multiple different conditions: 
-\begin{equation*}
-    P_{\alpha\beta}(\varphi) \sim  \det \left|\alpha\Omega_1 +\beta\Omega_2\right|\exp\left(-\frac{1}{2} (\vec{\varphi},(\alpha\Omega_1 + \beta\Omega_2)\vec{\varphi})\right)
-\end{equation*}
+  If distribution $P(\alpha|f)$ is narrow it will produce approximately same
+  result. And it's the case for our example problem
+\end{enumerate}
 
-This features allow to combine different types of parametric prior information. Also one can use non-parametric prior. For example, information about non-negativity:
+Derivation above assumed that $\Omega$ if positive definite. It possible to
+accommodate singular $\Omega$. Then $\det$ in~(\ref{eq-prior}) should be
+replaced with pseudodeterminant. Positive definiteness is desirable since
+regularization is guaranteed to work only for non-singular $\Omega$ and singular
+or even near-singular $\Omega$ may and likely will cause numerical problems.
+
+Also note that $\Omega$ we use is singular since $\varphi = kx + b$ will have
+smoothness equal to zero. One way fix it is to fix value of $\varphi$ to 0 and
+boundaries or to put priors on values on
+boundaries\cite{calvetti2006aristotelian}. In that case $\alpha\Omega$
+in~(\ref{eq-prior}) should be replaced with $\sum_i\alpha_i\Omega_i$ where
+different $\Omega_i$ corresponds to smoothness, boundary values etc.
+
+Also it's possible to add any other prior information about function. For
+example it possible to add non-negativity:
+
 \begin{equation*}
     P(\varphi) \sim P_{\alpha}(\varphi)P(\varphi(x) > 0)
 \end{equation*}
+
 
 \subsection{Discretization}
 

--- a/AYSS-2017/article/references.bib
+++ b/AYSS-2017/article/references.bib
@@ -75,3 +75,11 @@ issn="1434-6079",
 doi="10.1007/s100530050525",
 url="https://doi.org/10.1007/s100530050525"
 }
+@article{calvetti2006aristotelian,
+  title		={Aristotelian prior boundary conditions},
+  author	={Calvetti, Daniela and Kaipio, Jari P and Somersalo, Erkki},
+  journal	={Int. J. Math},
+  volume	={1},
+  pages		={63--81},
+  year		={2006}
+}


### PR DESCRIPTION
Я почитал-почитал раздел про выбор априорной вероятности, плюнул и переписал его весь. Что  мне не нравилось: довольно невнятное в целом изложение. Почему мы минизируем информацию? Откуда вообще взялась гладкость? В какой момент α стала случайной переменной? 

- Я добавил обсуждение проблем с сингулярной Ω и обсуждение добавление гранусловий со ссылкой. 

- Выкинул пункт 4 (use posterior information about smoothness) т.к. сам его не понял

Сейчас он немного не лезет в 5 страниц, но там можно что-нибудь урезать. Давай обсуждать